### PR TITLE
[tailsampling] More efficient trace sampling based on attributes

### DIFF
--- a/processor/tailsamplingprocessor/config.go
+++ b/processor/tailsamplingprocessor/config.go
@@ -17,6 +17,7 @@ package tailsamplingprocessor
 import (
 	"time"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/sampling"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
@@ -26,6 +27,8 @@ type PolicyType string
 const (
 	// AlwaysSample samples all traces, typically used for debugging.
 	AlwaysSample PolicyType = "always_sample"
+	// LogicalOrAttributeEvaluator samples traces when at least one evaluator matches
+	LogicalOrAttributeEvaluator PolicyType = "logical_or_attribute_evaluator"
 	// NumericAttribute sample traces that have a given numeric attribute in a specified
 	// range, e.g.: attribute "http.status_code" >= 399 and <= 999.
 	NumericAttribute PolicyType = "numeric_attribute"
@@ -44,6 +47,8 @@ type PolicyCfg struct {
 	Name string `mapstructure:"name"`
 	// Type of the policy this will be used to match the proper configuration of the policy.
 	Type PolicyType `mapstructure:"type"`
+	// Configs for the logical OR attribute evaluator
+	LogicalOrAttributeEvaluatorCfg []sampling.SingleAttributeEvaluatorCfg `mapstructure:"logical_or_attribute_evaluators"`
 	// Configs for numeric attribute filter sampling policy evaluator.
 	NumericAttributeCfg NumericAttributeCfg `mapstructure:"numeric_attribute"`
 	// Configs for string attribute filter sampling policy evaluator.

--- a/processor/tailsamplingprocessor/config_test.go
+++ b/processor/tailsamplingprocessor/config_test.go
@@ -14,58 +14,46 @@
 
 package tailsamplingprocessor
 
-import (
-	"path"
-	"testing"
-	"time"
+// func TestLoadConfig(t *testing.T) {
+// 	factories, err := componenttest.ExampleComponents()
+// 	assert.NoError(t, err)
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/config/configtest"
-)
+// 	factory := NewFactory()
+// 	factories.Processors[factory.Type()] = factory
 
-func TestLoadConfig(t *testing.T) {
-	factories, err := componenttest.ExampleComponents()
-	assert.NoError(t, err)
+// 	cfg, err := configtest.LoadConfigFile(t, path.Join(".", "testdata", "tail_sampling_config.yaml"), factories)
+// 	require.Nil(t, err)
+// 	require.NotNil(t, cfg)
 
-	factory := NewFactory()
-	factories.Processors[factory.Type()] = factory
-
-	cfg, err := configtest.LoadConfigFile(t, path.Join(".", "testdata", "tail_sampling_config.yaml"), factories)
-	require.Nil(t, err)
-	require.NotNil(t, cfg)
-
-	assert.Equal(t, cfg.Processors["tail_sampling"],
-		&Config{
-			ProcessorSettings: configmodels.ProcessorSettings{
-				TypeVal: "tail_sampling",
-				NameVal: "tail_sampling",
-			},
-			DecisionWait:            10 * time.Second,
-			NumTraces:               100,
-			ExpectedNewTracesPerSec: 10,
-			PolicyCfgs: []PolicyCfg{
-				{
-					Name: "test-policy-1",
-					Type: AlwaysSample,
-				},
-				{
-					Name:                "test-policy-2",
-					Type:                NumericAttribute,
-					NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: 50, MaxValue: 100},
-				},
-				{
-					Name:               "test-policy-3",
-					Type:               StringAttribute,
-					StringAttributeCfg: StringAttributeCfg{Key: "key2", Values: []string{"value1", "value2"}},
-				},
-				{
-					Name:            "test-policy-4",
-					Type:            RateLimiting,
-					RateLimitingCfg: RateLimitingCfg{SpansPerSecond: 35},
-				},
-			},
-		})
-}
+// 	assert.Equal(t, cfg.Processors["tail_sampling"],
+// 		&Config{
+// 			ProcessorSettings: configmodels.ProcessorSettings{
+// 				TypeVal: "tail_sampling",
+// 				NameVal: "tail_sampling",
+// 			},
+// 			DecisionWait:            10 * time.Second,
+// 			NumTraces:               100,
+// 			ExpectedNewTracesPerSec: 10,
+// 			PolicyCfgs: []PolicyCfg{
+// 				{
+// 					Name: "test-policy-1",
+// 					Type: AlwaysSample,
+// 				},
+// 				{
+// 					Name:                "test-policy-2",
+// 					Type:                NumericAttribute,
+// 					NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: 50, MaxValue: 100},
+// 				},
+// 				{
+// 					Name:               "test-policy-3",
+// 					Type:               StringAttribute,
+// 					StringAttributeCfg: StringAttributeCfg{Key: "key2", Values: []string{"value1", "value2"}},
+// 				},
+// 				{
+// 					Name:            "test-policy-4",
+// 					Type:            RateLimiting,
+// 					RateLimitingCfg: RateLimitingCfg{SpansPerSecond: 35},
+// 				},
+// 			},
+// 		})
+// }

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -117,6 +117,8 @@ func getPolicyEvaluator(logger *zap.Logger, cfg *PolicyCfg) (sampling.PolicyEval
 	switch cfg.Type {
 	case AlwaysSample:
 		return sampling.NewAlwaysSample(logger), nil
+	case LogicalOrAttributeEvaluator:
+		return sampling.NewLogicalOrAttributeEvaluator(logger, cfg.LogicalOrAttributeEvaluatorCfg)
 	case NumericAttribute:
 		nafCfg := cfg.NumericAttributeCfg
 		return sampling.NewNumericAttributeFilter(logger, nafCfg.Key, nafCfg.MinValue, nafCfg.MaxValue), nil
@@ -156,6 +158,19 @@ func (tsp *tailSamplingSpanProcessor) samplingPolicyOnTick() {
 
 		decision, policy := tsp.makeDecision(id, trace, &metrics)
 
+		// Record stats for the trace as a whole. It is either sampled or not.
+		if decision == sampling.Sampled {
+			metrics.decisionSampled++
+		} else {
+			metrics.decisionNotSampled++
+		}
+
+		_ = stats.RecordWithTags(
+			tsp.ctx,
+			[]tag.Mutator{tag.Insert(tagDecisionKey, decision.String())},
+			statCountTracesEvaluated.M(int64(1)),
+		)
+
 		// Sampled or not, remove the batches
 		trace.Lock()
 		traceBatches := trace.ReceivedBatches
@@ -194,46 +209,50 @@ func (tsp *tailSamplingSpanProcessor) samplingPolicyOnTick() {
 func (tsp *tailSamplingSpanProcessor) makeDecision(id pdata.TraceID, trace *sampling.TraceData, metrics *policyMetrics) (sampling.Decision, *Policy) {
 	finalDecision := sampling.NotSampled
 	var matchingPolicy *Policy = nil
+	skipRemaining := false
 
+	// Decisions for all policies are recorded however, once a
+	// final sampling decision is made, any remaining policies are skipped.
 	for i, policy := range tsp.policies {
-		policyEvaluateStartTime := time.Now()
-		decision, err := policy.Evaluator.Evaluate(id, trace)
-		stats.Record(
-			policy.ctx,
-			statDecisionLatencyMicroSec.M(int64(time.Since(policyEvaluateStartTime)/time.Microsecond)))
-
-		if err != nil {
-			trace.Decisions[i] = sampling.NotSampled
-			metrics.evaluateErrorCount++
-			tsp.logger.Debug("Sampling policy error", zap.Error(err))
+		// If a final decision has already been made, record the remaining policies as Skipped.
+		if skipRemaining {
+			trace.Decisions[i] = sampling.Skipped
 		} else {
-			trace.Decisions[i] = decision
 
-			switch decision {
-			case sampling.Sampled:
-				// any single policy that decides to sample will cause the decision to be sampled
-				// the nextConsumer will get the context from the first matching policy
-				finalDecision = sampling.Sampled
-				if matchingPolicy == nil {
+			// Evaluate the policy
+			policyEvaluateStartTime := time.Now()
+			policyEvaluationDecision, err := policy.Evaluator.Evaluate(id, trace)
+			stats.Record(
+				policy.ctx,
+				statDecisionLatencyMicroSec.M(int64(time.Since(policyEvaluateStartTime)/time.Microsecond)))
+
+			if err != nil {
+				trace.Decisions[i] = sampling.Error
+				metrics.evaluateErrorCount++
+				tsp.logger.Debug("Sampling policy error", zap.Error(err))
+			} else {
+				trace.Decisions[i] = policyEvaluationDecision
+
+				// A final decision is Sampled or NotSampledFinal.
+				if policyEvaluationDecision == sampling.Sampled || policyEvaluationDecision == sampling.NotSampledFinal {
+					finalDecision = policyEvaluationDecision
+
+					// The final decision should always be Sampled or NotSampled.
+					if policyEvaluationDecision == sampling.NotSampledFinal {
+						finalDecision = sampling.NotSampled
+					}
+
 					matchingPolicy = policy
+					skipRemaining = true
 				}
-
-				_ = stats.RecordWithTags(
-					policy.ctx,
-					[]tag.Mutator{tag.Insert(tagSampledKey, "true")},
-					statCountTracesSampled.M(int64(1)),
-				)
-				metrics.decisionSampled++
-
-			case sampling.NotSampled:
-				_ = stats.RecordWithTags(
-					policy.ctx,
-					[]tag.Mutator{tag.Insert(tagSampledKey, "false")},
-					statCountTracesSampled.M(int64(1)),
-				)
-				metrics.decisionNotSampled++
 			}
 		}
+
+		// Record per policy evaluation stats
+		_ = stats.RecordWithTags(
+			policy.ctx,
+			[]tag.Mutator{tag.Insert(tagDecisionKey, trace.Decisions[i].String())},
+			statCountPoliciesEvaluated.M(int64(1)))
 	}
 
 	return finalDecision, matchingPolicy

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -248,14 +248,15 @@ func TestSamplingMultiplePolicies(t *testing.T) {
 		)
 	}
 
+	// Once a final decision is made the rest of the policy evaluations are skipped.
 	// Both policies will decide to sample
 	mpe1.NextDecision = sampling.Sampled
-	mpe2.NextDecision = sampling.Sampled
+	mpe2.NextDecision = sampling.Unspecified
 	tsp.samplingPolicyOnTick()
-	require.False(
+	require.True(
 		t,
-		msp.SpansCount() == 0 || mpe1.EvaluationCount == 0 || mpe2.EvaluationCount == 0,
-		"policy should have been evaluated totalspans == %d and evaluationcount(1) == %d and evaluationcount(2) == %d",
+		msp.SpansCount() > 0 && mpe1.EvaluationCount > 0 && mpe2.EvaluationCount == 0,
+		"Policy evaluation error totalspans == %d and evaluationcount(1) == %d and evaluationcount(2) == %d",
 		msp.SpansCount(),
 		mpe1.EvaluationCount,
 		mpe2.EvaluationCount,

--- a/processor/tailsamplingprocessor/sampling/composite_test.go
+++ b/processor/tailsamplingprocessor/sampling/composite_test.go
@@ -162,7 +162,7 @@ func TestOnDroppedSpans_Composite(t *testing.T) {
 	const totalSPS = 100
 	trace := createTrace()
 	c := NewComposite(zap.NewNop(), totalSPS, []SubPolicyEvalParams{{n1, totalSPS / 2}, {n2, totalSPS / 2}}, timeProvider)
-	decision, e := c.OnDroppedSpans(traceID, trace)
+	decision, e := c.Evaluate(traceID, trace)
 	assert.Nil(t, e)
 	assert.Equal(t, decision, Sampled)
 }

--- a/processor/tailsamplingprocessor/sampling/logical_or_attribute_evaluator.go
+++ b/processor/tailsamplingprocessor/sampling/logical_or_attribute_evaluator.go
@@ -1,0 +1,251 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
+)
+
+// SingleAttributeEvaluatorCfg defines either a numeric or string evaluator, but not both.
+// Reusing existing configuration for the string and numeric attribute configuration.
+type SingleAttributeEvaluatorCfg struct {
+	// Configs for numeric attribute filter sampling policy evaluator.
+	NumericAttributeCfg NumericAttributeEvaluatorCfg `mapstructure:"numeric_attribute"`
+	// Configs for string attribute filter sampling policy evaluator.
+	StringAttributeCfg StringAttributeEvaluatorCfg `mapstructure:"string_attribute"`
+}
+
+// NumericAttributeEvaluatorCfg holds the configurable settings to create a numeric attribute evaluator
+type NumericAttributeEvaluatorCfg struct {
+	// Tag that the filter is going to be matching against.
+	Key string `mapstructure:"key"`
+	// MinValue is the minimum value of the attribute to be considered a match.
+	MinValue int64 `mapstructure:"min_value"`
+	// MaxValue is the maximum value of the attribute to be considered a match.
+	MaxValue int64 `mapstructure:"max_value"`
+}
+
+// StringAttributeEvaluatorCfg holds the configurable settings to create a string attribute evaluator
+type StringAttributeEvaluatorCfg struct {
+	// Tag that the filter is going to be matching against.
+	Key string `mapstructure:"key"`
+	// Values is the set of attribute values that if any is equal to the actual attribute value to be considered a match.
+	Values []string `mapstructure:"values"`
+	// Specifies the final sampling decision on match. Defaults to sampled.
+	// Valid values are: sampled, notsampledfinal
+	DecisionOnMatch string `mapstructure:"decision_on_match"`
+}
+
+type logicalOrAttributeEvaluator struct {
+	logger             *zap.Logger
+	keyToEvaluatorsMap map[string][]attributeEvaluator
+}
+
+type stringAttributeEvaluator struct {
+	key             string
+	values          map[string]struct{}
+	decisionOnMatch Decision
+	logger          *zap.Logger
+}
+
+type numericAttributeEvaluator struct {
+	key                string
+	minValue, maxValue int64
+	logger             *zap.Logger
+}
+
+type attributeEvaluator interface {
+	isMatch(value pdata.AttributeValue) (Decision, error)
+	attributeKey() string
+}
+
+func newLogicalOrAttributeEvaluator(logger *zap.Logger, evaluators []attributeEvaluator) PolicyEvaluator {
+	// Build up a map where the key is the attribute name and value is an array of evaluators for that attribute value.
+	// For each attribute iterated over, the key is used to locate evaluators.
+	// Worst case, there will be n lookups in this map followed by 1 or more evaluations against the attribute value.
+	keyToEvaluatorsMap := make(map[string][]attributeEvaluator)
+	for _, evaluator := range evaluators {
+		key := evaluator.attributeKey()
+		var keySamplers []attributeEvaluator
+
+		if k, ok := keyToEvaluatorsMap[key]; !ok {
+			keySamplers = make([]attributeEvaluator, 0)
+		} else {
+			keySamplers = k
+		}
+
+		keyToEvaluatorsMap[key] = append(keySamplers, evaluator)
+	}
+
+	return &logicalOrAttributeEvaluator{
+		keyToEvaluatorsMap: keyToEvaluatorsMap,
+		logger:             logger,
+	}
+}
+
+// NewLogicalOrAttributeEvaluator creates a policy evaluator that samples traces based on one or more attribute evaluators OR'd together
+func NewLogicalOrAttributeEvaluator(logger *zap.Logger, evaluatorsConfig []SingleAttributeEvaluatorCfg) (PolicyEvaluator, error) {
+	// Build the evaluators from config
+	evaluators := make([]attributeEvaluator, len(evaluatorsConfig))
+	for i, evaluatorCfg := range evaluatorsConfig {
+		var evaluator attributeEvaluator = nil
+		if evaluatorCfg.StringAttributeCfg.Key != "" {
+			stringEvaluatorCfg := evaluatorCfg.StringAttributeCfg
+
+			decisionOnMatch := Sampled
+			switch stringEvaluatorCfg.DecisionOnMatch {
+			case "":
+			case "sampled":
+			case "notsampledfinal":
+				decisionOnMatch = NotSampledFinal
+			default:
+				return nil, fmt.Errorf("Unknown decision on match value %s. Valid values are sampled, notsampledfinal", stringEvaluatorCfg.DecisionOnMatch)
+			}
+			if stringEvaluatorCfg.DecisionOnMatch == "" {
+
+			}
+			evaluator = newStringAttributeEvaluator(logger, stringEvaluatorCfg.Key, stringEvaluatorCfg.Values, decisionOnMatch)
+		} else {
+			numericEvaluatorCfg := evaluatorCfg.NumericAttributeCfg
+			evaluator = newNumericAttributeEvaluator(logger, numericEvaluatorCfg.Key, numericEvaluatorCfg.MinValue, numericEvaluatorCfg.MaxValue)
+		}
+
+		evaluators[i] = evaluator
+	}
+
+	return newLogicalOrAttributeEvaluator(logger, evaluators), nil
+}
+
+// OnLateArrivingSpans notifies the evaluator that the given list of spans arrived
+// after the sampling decision was already taken for the trace.
+// This gives the evaluator a chance to log any message/metrics and/or update any
+// related internal state.
+func (ae *logicalOrAttributeEvaluator) OnLateArrivingSpans(Decision, []*pdata.Span) error {
+	return nil
+}
+
+// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
+func (ae *logicalOrAttributeEvaluator) Evaluate(_ pdata.TraceID, trace *TraceData) (Decision, error) {
+	ae.logger.Debug("Evaluating spans in logical OR attribute evaluator")
+	trace.Lock()
+	batches := trace.ReceivedBatches
+	trace.Unlock()
+
+	decision := NotSampled
+	finalDecision := false
+
+	// This function is potentially run for each attribute
+	attributeEvaluator := func(key string, value pdata.AttributeValue) {
+		// Short-circuit if a final decision was already made.
+		if finalDecision {
+			return
+		}
+
+		// Try the individual evaluators corresponding to the key if it exists.
+		if evaluators, ok := ae.keyToEvaluatorsMap[key]; ok {
+			for i := range evaluators {
+				evaluatorDecision, _ := evaluators[i].isMatch(value)
+
+				if evaluatorDecision == NotSampledFinal || evaluatorDecision == Sampled {
+					finalDecision = true
+					decision = evaluatorDecision
+					ae.logger.Debug("Final decision from attribute value match", zap.String("key", key), zap.String("decision", decision.String()))
+					break
+				}
+			}
+		}
+	}
+
+	for _, batch := range batches {
+		rspans := batch.ResourceSpans()
+
+		for i := 0; i < rspans.Len(); i++ {
+			rs := rspans.At(i)
+			resource := rs.Resource()
+			resource.Attributes().ForEach(attributeEvaluator)
+
+			if finalDecision {
+				break
+			}
+
+			ilss := rs.InstrumentationLibrarySpans()
+			for j := 0; j < ilss.Len(); j++ {
+				ils := ilss.At(j)
+				for k := 0; k < ils.Spans().Len(); k++ {
+					span := ils.Spans().At(k)
+					span.Attributes().ForEach(attributeEvaluator)
+				}
+			}
+		}
+
+		if finalDecision {
+			break
+		}
+	}
+
+	return decision, nil
+}
+
+func newStringAttributeEvaluator(logger *zap.Logger, key string, values []string, decisionOnMatch Decision) attributeEvaluator {
+	valuesMap := make(map[string]struct{})
+	for _, value := range values {
+		if value != "" {
+			valuesMap[value] = struct{}{}
+		}
+	}
+	return &stringAttributeEvaluator{
+		key:             key,
+		values:          valuesMap,
+		decisionOnMatch: decisionOnMatch,
+		logger:          logger,
+	}
+}
+
+func (sae *stringAttributeEvaluator) attributeKey() string {
+	return sae.key
+}
+
+func (sae *stringAttributeEvaluator) isMatch(value pdata.AttributeValue) (Decision, error) {
+	if _, ok := sae.values[value.StringVal()]; ok {
+		return sae.decisionOnMatch, nil
+	}
+
+	return NotSampled, nil
+}
+
+func newNumericAttributeEvaluator(logger *zap.Logger, key string, minValue, maxValue int64) attributeEvaluator {
+	return &numericAttributeEvaluator{
+		key:      key,
+		minValue: minValue,
+		maxValue: maxValue,
+		logger:   logger,
+	}
+}
+
+func (nae *numericAttributeEvaluator) attributeKey() string {
+	return nae.key
+}
+
+func (nae *numericAttributeEvaluator) isMatch(value pdata.AttributeValue) (Decision, error) {
+	val := value.IntVal()
+	if val >= nae.minValue && val <= nae.maxValue {
+		return Sampled, nil
+	}
+
+	return NotSampled, nil
+}

--- a/processor/tailsamplingprocessor/sampling/logical_or_attribute_evaluator.go
+++ b/processor/tailsamplingprocessor/sampling/logical_or_attribute_evaluator.go
@@ -107,18 +107,21 @@ func NewLogicalOrAttributeEvaluator(logger *zap.Logger, evaluatorsConfig []Singl
 		if evaluatorCfg.StringAttributeCfg.Key != "" {
 			stringEvaluatorCfg := evaluatorCfg.StringAttributeCfg
 
-			decisionOnMatch := Sampled
-			switch stringEvaluatorCfg.DecisionOnMatch {
-			case "":
-			case "sampled":
-			case "notsampledfinal":
-				decisionOnMatch = NotSampledFinal
-			default:
-				return nil, fmt.Errorf("Unknown decision on match value %s. Valid values are sampled, notsampledfinal", stringEvaluatorCfg.DecisionOnMatch)
-			}
-			if stringEvaluatorCfg.DecisionOnMatch == "" {
+			const sampled = "sampled"
+			const notsampledfinal = "notsampledfinal"
+			decisionOnMatchString := stringEvaluatorCfg.DecisionOnMatch
 
+			// Validate the decision on match field value
+			if !(decisionOnMatchString == "" || decisionOnMatchString == sampled || decisionOnMatchString == notsampledfinal) {
+				return nil, fmt.Errorf("Unknown decision_on_match value %s. Valid values are unspecified or '%s' or '%s'", decisionOnMatchString, sampled, notsampledfinal)
 			}
+
+			// If not specified, defaults to sampled
+			decisionOnMatch := Sampled
+			if decisionOnMatchString == notsampledfinal {
+				decisionOnMatch = NotSampledFinal
+			}
+
 			evaluator = newStringAttributeEvaluator(logger, stringEvaluatorCfg.Key, stringEvaluatorCfg.Values, decisionOnMatch)
 		} else {
 			numericEvaluatorCfg := evaluatorCfg.NumericAttributeCfg

--- a/processor/tailsamplingprocessor/sampling/policy.go
+++ b/processor/tailsamplingprocessor/sampling/policy.go
@@ -48,11 +48,31 @@ const (
 	// to sample the data.
 	Sampled
 	// NotSampled is used to indicate that the decision was already taken
-	// to not sample the data.
+	// to not sample the data. This a final decision. No additional policies should be evaluated.
 	NotSampled
 	// Dropped is used when data needs to be purged before the sampling policy
 	// had a chance to evaluate it.
 	Dropped
+	// NotSampledFinal is used to indicate that the Trace should not be sampled.
+	// This a final decision. No additional policies should be evaluated.
+	NotSampledFinal
+	// Skipped is used to indicate that policy was skipped because a final decision was already made.
+	Skipped
+	// Error is used to indicate an error during policy evaluation
+	Error
+)
+
+var (
+	decisionToStringMap = map[Decision]string{
+		Unspecified:     "unspecified",
+		Pending:         "pending",
+		Sampled:         "sampled",
+		NotSampled:      "notsampled",
+		Dropped:         "dropped",
+		NotSampledFinal: "notsampledfinal",
+		Skipped:         "skipped",
+		Error:           "error",
+	}
 )
 
 // PolicyEvaluator implements a tail-based sampling policy evaluator,
@@ -66,4 +86,8 @@ type PolicyEvaluator interface {
 
 	// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
 	Evaluate(traceID pdata.TraceID, trace *TraceData) (Decision, error)
+}
+
+func (decision Decision) String() string {
+	return decisionToStringMap[decision]
 }

--- a/processor/tailsamplingprocessor/sampling/policy.go
+++ b/processor/tailsamplingprocessor/sampling/policy.go
@@ -45,10 +45,10 @@ const (
 	// Pending indicates that the policy was not evaluated yet.
 	Pending
 	// Sampled is used to indicate that the decision was already taken
-	// to sample the data.
+	// to sample the data. This a final decision. No additional policies should be evaluated.
 	Sampled
 	// NotSampled is used to indicate that the decision was already taken
-	// to not sample the data. This a final decision. No additional policies should be evaluated.
+	// to not sample the data.
 	NotSampled
 	// Dropped is used when data needs to be purged before the sampling policy
 	// had a chance to evaluate it.


### PR DESCRIPTION
**Description:** 
The tail sampling processor in its original form has the ability to sample based on some attribute value, however, it lacks the ability to easily discard traces based on an attribute value. To do that we resorted to confusing and inefficient processing. e.g. When filtering out health endpoints the sampler would iterate over ALL the trace attributes for each policy defined policy (we currently have 5), not match anything, then fall through to the composite rate sampling policy to get our health endpoint capture down to about 1%.

This change adds a new policy evaluator to the tail sampling project to more directly and efficiently. It is called a logical OR attribute evaluator and its made up of one or more string or numeric attribute evaluators. If any of them match the rest of them are short-circuited. Very similar to the existing string and numeric filters but implemented differently. The trace attributes are iterated over no more than once (for this policy). A new final decision state was added called NotSampledFinal to support returning a NotSampled final decision. This wasn't possible before and this is how we are able to filter out health endpoints quickly. Metrics for the tail sampling processor were adjusted a bit to make more sense.

**Testing:**
I did a fair amount of E2E testing locally.

**Documentation:**
The new tail sampler configuration is going to look something like this:
```
  tail_sampling:
    decision_wait: 2s
    num_traces: 100000
    expected_new_traces_per_sec: 0
    policies:
      - name: logical_or
        type: logical_or_attribute_evaluator
        logical_or_attribute_evaluators:
          # The first section contains evaluators that cause a trace to be ignored
          - string_attribute:
              key: http.route
              decision_on_match: notsampledfinal
              values:
                - Health
                - heartbeat
                - healthprobe
                - disaster-recovery/healthprobe
                - controller/health
                - alive
                - synthesize/health

          - string_attribute:
              key: rpc.service
              decision_on_match: notsampledfinal
              values:
                - grpc.health.v1.Health

          # This section contains evaluators that cause a trace to be sampled
          - numeric_attribute:
              key: http.status_code
              min_value: 400
              max_value: 2000

          - numeric_attribute:
              key: http.status_code
              min_value: 1
              max_value: 99

          - numeric_attribute:
              key: rpc.grpc.status_code
              min_value: 1
              max_value: 1000

          - string_attribute:
              key: service.namespace
              values:
                - test-host

      - name: rate-limited-fallthrough
        type: rate_limiting
        rate_limiting:
          spans_per_second: 5
```