### PR TITLE
[tailsampling] NotSampledFinal and Skipped states are valid for logging purposes

### DIFF
--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -354,6 +354,10 @@ func (tsp *tailSamplingSpanProcessor) processTraces(resourceSpans pdata.Resource
 				policy.Evaluator.OnLateArrivingSpans(actualDecision, spans)
 				stats.Record(tsp.ctx, statLateSpanArrivalAfterDecision.M(int64(time.Since(actualData.DecisionTime)/time.Second)))
 
+			// Ignore these
+			case sampling.NotSampledFinal:
+			case sampling.Skipped:
+
 			default:
 				tsp.logger.Warn("Encountered unexpected sampling decision",
 					zap.String("policy", policy.Name),


### PR DESCRIPTION
The previous code loops through the policy decisions and does some logging, but doesn't understand the newly added NotSampledFinal and Skipped states. This change just ignores them in this particular code area.